### PR TITLE
Check user-specified algorithm is supported in oll.oll()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Currently, OLL 0.03 supports following algorithms:
 
 - Perceptron
 - Averaged Perceptron
-- Passive Agressive (PA, PA-I, PA-II)
+- Passive Agressive (PA, PA-I, PA-II, Kernelized)
 - ALMA (modified slightly from original)
 - Confidence Weighted Linear-Classification.
 

--- a/oll/oll.py
+++ b/oll/oll.py
@@ -422,6 +422,11 @@ class oll(_object):
             "CW": lambda *args: _oll.oll_trainExampleCW(self, *args),
             "AL": lambda *args: _oll.oll_trainExampleAL(self, *args)
         }
+
+        if algorithm not in algorithms:
+            raise ValueError('Unsupported learning algorithm: {0}\n{1}'.format(
+                algorithm, oll.__init__.__doc__))
+
         self.train_method = functools.partial(train_methods[algorithm],
                                               algorithms[algorithm.upper()]())
         self.setC(C)

--- a/test_oll.py
+++ b/test_oll.py
@@ -16,7 +16,7 @@ class Test_oll(object):
 
     def test_invalid__init__(self):
         for method_name in ('AWP', 'PY'):
-            assert_raises(KeyError, oll.oll, method_name)
+            assert_raises(ValueError, oll.oll, method_name)
         assert_raises(AssertionError, oll.oll, 0)
 
     def test_add(self):


### PR DESCRIPTION
Also, mention Kernelized Passive Aggressive is supported in README.rst.

BTW, I like this Python binding :)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ikegami-yukino/oll-python/1)

<!-- Reviewable:end -->
